### PR TITLE
Fix API file names so they are picked up by the upgrader and ensure t…

### DIFF
--- a/CRM/Owngroups/Upgrader.php
+++ b/CRM/Owngroups/Upgrader.php
@@ -74,6 +74,18 @@ class CRM_Owngroups_Upgrader extends CRM_Owngroups_Upgrader_Base {
    * @return TRUE on success
    * @throws Exception
    */
+  public function upgrade_1000() {
+    $this->ctx->log->info('Applying update 1000: Create Table to store preference group');
+    $this->executeSqlFile('sql/upgrade_1000.sql');
+    return TRUE;
+  }
+
+  /**
+   * Example: Run a couple simple queries.
+   *
+   * @return TRUE on success
+   * @throws Exception
+   */
    public function upgrade_1100() {
      $this->ctx->log->info('Applying update 1100: Add Preference for existing groups');
      $groups = [

--- a/api/v3/PreferenceGroup/Createpreference.php
+++ b/api/v3/PreferenceGroup/Createpreference.php
@@ -13,7 +13,7 @@ use CRM_Owngroups_ExtensionUtil as E;
  *
  * @throws API_Exception
  */
-function civicrm_api3_preference_group_Createpreference($params) {
+function civicrm_api3_preference_group_createpreference($params) {
   $returnValues = CRM_Owngroups_BAO_PreferenceGroup::create($params);
   return civicrm_api3_create_success($returnValues, $params, 'PreferenceGroup', 'Createpreference');
 }

--- a/api/v3/PreferenceGroup/Getpreference.php
+++ b/api/v3/PreferenceGroup/Getpreference.php
@@ -13,7 +13,7 @@ use CRM_Owngroups_ExtensionUtil as E;
  *
  * @throws API_Exception
  */
-function civicrm_api3_preference_group_Getpreference($params) {
+function civicrm_api3_preference_group_getpreference($params) {
   $returnValues = CRM_Owngroups_BAO_PreferenceGroup::get($params);
   return civicrm_api3_create_success($returnValues, $params, 'PreferenceGroup', 'GetPreference');
 }

--- a/sql/upgrade_1000.sql
+++ b/sql/upgrade_1000.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS `civicrm_preference_group` (
+
+
+     `id` int unsigned NOT NULL AUTO_INCREMENT  COMMENT 'Unique PreferenceGroup ID',
+     `group_id` int unsigned    COMMENT 'FK to Group',
+     `is_preference` int unsigned    COMMENT 'Is this group shown on preference page' 
+,
+        PRIMARY KEY (`id`)
+ 
+ 
+,          CONSTRAINT FK_civicrm_preference_group_group_id FOREIGN KEY (`group_id`) REFERENCES `civicrm_group`(`id`) ON DELETE CASCADE  
+);


### PR DESCRIPTION
…hat the database table is properly created on upgrade

@Edzelopez I found a couple of things 1. the API wasn't finding the methods that were needed and 2) when i ran the extension upgrades on wordpress staging it failed initially because the table wasn't there